### PR TITLE
Add wrapping for timecode

### DIFF
--- a/bind/imf_timecode.cpp
+++ b/bind/imf_timecode.cpp
@@ -1,4 +1,5 @@
 #include <OpenEXR/ImfTimeCode.h>
+#include <OpenEXR/IexBaseExc.h>
 
 #include <cppmm_bind.hpp>
 
@@ -21,14 +22,14 @@ struct TimeCode {
              bool fieldPhase = false, bool bgf0 = false, bool bgf1 = false,
              bool bgf2 = false, int binaryGroup1 = 0, int binaryGroup2 = 0,
              int binaryGroup3 = 0, int binaryGroup4 = 0, int binaryGroup5 = 0,
-             int binaryGroup6 = 0, int binaryGroup7 = 0, int binaryGroup8 = 0);
+             int binaryGroup6 = 0, int binaryGroup7 = 0, int binaryGroup8 = 0) CPPMM_RENAME(ctor);
 
     IMF_EXPORT
     TimeCode(unsigned int timeAndFlags, unsigned int userData,
              Imf::TimeCode::Packing packing) CPPMM_RENAME(from_time_and_flags);
 
     IMF_EXPORT
-    TimeCode(const Imf::TimeCode& other);
+    TimeCode(const Imf::TimeCode& other) CPPMM_RENAME(copy);
 
     ~TimeCode() = default;
 
@@ -42,22 +43,22 @@ struct TimeCode {
     IMF_EXPORT
     int hours() const;
     IMF_EXPORT
-    void setHours(int value);
+    void setHours(int value) CPPMM_THROWS(Iex::ArgExc, IEX_INVALID_ARGUMENT);
 
     IMF_EXPORT
     int minutes() const;
     IMF_EXPORT
-    void setMinutes(int value);
+    void setMinutes(int value) CPPMM_THROWS(Iex::ArgExc, IEX_INVALID_ARGUMENT);
 
     IMF_EXPORT
     int seconds() const;
     IMF_EXPORT
-    void setSeconds(int value);
+    void setSeconds(int value) CPPMM_THROWS(Iex::ArgExc, IEX_INVALID_ARGUMENT);
 
     IMF_EXPORT
     int frame() const;
     IMF_EXPORT
-    void setFrame(int value);
+    void setFrame(int value) CPPMM_THROWS(Iex::ArgExc, IEX_INVALID_ARGUMENT);
 
     IMF_EXPORT
     bool dropFrame() const;
@@ -90,9 +91,9 @@ struct TimeCode {
     void setBgf2(bool value);
 
     IMF_EXPORT
-    int binaryGroup(int group) const; // group must be between 1 and 8
+    int binaryGroup(int group) const CPPMM_THROWS(Iex::ArgExc, IEX_INVALID_ARGUMENT); // group must be between 1 and 8
     IMF_EXPORT
-    void setBinaryGroup(int group, int value);
+    void setBinaryGroup(int group, int value) CPPMM_THROWS(Iex::ArgExc, IEX_INVALID_ARGUMENT);
 
     IMF_EXPORT
     unsigned int timeAndFlags(Imf::TimeCode::Packing packing) const;

--- a/openexr-rs/src/lib.rs
+++ b/openexr-rs/src/lib.rs
@@ -67,6 +67,8 @@ pub use flat_image_channel::{FlatChannelF16, FlatChannelF32, FlatChannelU32};
 pub mod version;
 pub use version::{VersionFlags, Version};
 pub mod flat_image_io;
+pub mod timecode;
+pub use timecode::{TimeCode, TimeCodePacking};
 
 pub mod cppstd;
 

--- a/openexr-rs/src/timecode.rs
+++ b/openexr-rs/src/timecode.rs
@@ -1,0 +1,1107 @@
+use crate::Error;
+use openexr_sys as sys;
+use std::cmp::{Eq, PartialEq};
+use std::fmt::Debug;
+use std::mem::MaybeUninit;
+use std::os::raw::{c_int, c_uint};
+
+type Result<T, E = Error> = std::result::Result<T, E>;
+
+/// Bit packing variants
+///
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TimeCodePacking {
+    /// packing for 60-field television
+    ///
+    Tv60,
+    /// packing for 50-field television
+    ///
+    Tv50,
+    /// packing for 24-frame film
+    ///
+    Film24,
+}
+
+impl TimeCodePacking {
+    fn from_sys_packing(packing: sys::Imf_TimeCode_Packing) -> Self {
+        match packing {
+            sys::Imf_TimeCode_Packing_TV60_PACKING => TimeCodePacking::Tv60,
+            sys::Imf_TimeCode_Packing_TV50_PACKING => TimeCodePacking::Tv50,
+            sys::Imf_TimeCode_Packing_FILM24_PACKING => TimeCodePacking::Film24,
+            _ => panic!("Packing is invalid"),
+        }
+    }
+
+    fn to_sys_packing(&self) -> sys::Imf_TimeCode_Packing {
+        match self {
+            Self::Tv60 => sys::Imf_TimeCode_Packing_TV60_PACKING,
+            Self::Tv50 => sys::Imf_TimeCode_Packing_TV50_PACKING,
+            Self::Film24 => sys::Imf_TimeCode_Packing_FILM24_PACKING,
+        }
+    }
+}
+
+/// A TimeCode object stores time and control codes as described in SMPTE
+/// standard 12M-1999.  A TimeCode object contains the following fields:
+///
+/// Time Address:
+/// - hours: integer, range 0 - 23
+/// - minutes: integer, range 0 - 59
+/// - seconds: integer, range 0 - 59
+/// - frame: integer, range 0 - 29
+///
+/// Flags:
+/// - drop frame flag: boolean
+/// - color frame flag: boolean
+/// - field/phase flag: boolean
+/// - bgf0: boolean
+/// - bgf1: boolean
+/// - bgf2: boolean
+///
+/// Binary groups for user-defined data and control codes:
+/// - binary group 1: integer, range 0 - 15
+/// - binary group 2: integer, range 0 - 15
+/// - ...
+/// - binary group 8: integer, range 0 - 15
+///
+/// TimeCode contains methods to convert between the fields listed above and a
+/// more compact representation where the fields are packed into two unsigned
+/// 32-bit integers. In the packed integer representations, bit 0 is the least
+/// significant bit, and bit 31 is the most significant bit of the integer
+/// value. The time address and flags fields can be packed in three different
+/// ways:
+///
+/// | bits    | packing for 24-frame film | packing for 60-field television | packing for 50-field television |
+/// | ------- | ------------------------- | ------------------------------- | ------------------------------- |
+/// | 0 - 3   | frame units               | frame units                     | frame units                     |
+/// | 4 - 5   | frame tens                | frame tens                      | frame tens                      |
+/// | 6       | unused, set to 0          | drop frame flag                 | unused, set to 0                |
+/// | 7       | unused, set to 0          | color frame flag                | color frame flag                |
+/// | 8 - 11  | seconds units             | seconds units                   | seconds units                   |
+/// | 12 - 14 | seconds tens              | seconds tens                    | seconds tens                    |
+/// | 15      | phase flag                | field/phase flag                | bgf0                            |
+/// | 16 - 19 | minutes units             | minutes units                   | minutes units                   |
+/// | 20 - 22 | minutes tens              | minutes tens                    | minutes tens                    |
+/// | 23      | bgf0                      | bgf0                            | bgf2                            |
+/// | 24 - 27 | hours units               | hours units                     | hours units                     |
+/// | 28 - 29 | hours tens                | hours tens                      | hours tens                      |
+/// | 30      | bgf1                      | bgf1                            | bgf1                            |
+/// | 31      | bgf2                      | bgf2                            | field/phase flag                |
+///
+/// User-defined data and control codes are packed as follows:
+///
+/// | bits    | field          |
+/// | ------- | -------------- |
+/// | 0 - 3   | binary group 1 |
+/// | 4 - 7   | binary group 2 |
+/// | 8 - 11  | binary group 3 |
+/// | 12 - 15 | binary group 4 |
+/// | 16 - 19 | binary group 5 |
+/// | 20 - 23 | binary group 6 |
+/// | 24 - 27 | binary group 7 |
+/// | 28 - 31 | binary group 8 |
+///
+pub struct TimeCode {
+    inner: sys::Imf_TimeCode_t,
+}
+
+impl Default for TimeCode {
+    fn default() -> Self {
+        let mut inner = MaybeUninit::<sys::Imf_TimeCode_t>::uninit();
+
+        unsafe {
+            // Function does not raise errors, so skipping error checking.
+            sys::Imf_TimeCode_default(inner.as_mut_ptr());
+
+            Self {
+                inner: inner.assume_init(),
+            }
+        }
+    }
+}
+
+impl Debug for TimeCode {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("TimeCode")
+            .field("hours", &self.hours())
+            .field("minutes", &self.minutes())
+            .field("seconds", &self.seconds())
+            .field("frame", &self.frame())
+            .field("drop_frame", &self.drop_frame())
+            .field("color_frame", &self.color_frame())
+            .field("field_phase", &self.field_phase())
+            .field("bgf0", &self.bgf0())
+            .field("bgf1", &self.bgf1())
+            .field("bgf2", &self.bgf2())
+            .field("binary_group1", &self.binary_group(1).unwrap())
+            .field("binary_group2", &self.binary_group(2).unwrap())
+            .field("binary_group3", &self.binary_group(3).unwrap())
+            .field("binary_group4", &self.binary_group(4).unwrap())
+            .field("binary_group5", &self.binary_group(5).unwrap())
+            .field("binary_group6", &self.binary_group(6).unwrap())
+            .field("binary_group7", &self.binary_group(7).unwrap())
+            .field("binary_group8", &self.binary_group(8).unwrap())
+            .finish()
+    }
+}
+
+impl Clone for TimeCode {
+    fn clone(&self) -> Self {
+        let mut other = MaybeUninit::<sys::Imf_TimeCode_t>::uninit();
+
+        unsafe {
+            // Function does not raise errors, so skipping error checking.
+            sys::Imf_TimeCode_copy(other.as_mut_ptr(), &self.inner);
+
+            Self {
+                inner: other.assume_init(),
+            }
+        }
+    }
+}
+
+impl Drop for TimeCode {
+    fn drop(&mut self) {
+        unsafe {
+            // Function does not raise errors, so skipping error checking.
+            sys::Imf_TimeCode_dtor(&mut self.inner);
+        }
+    }
+}
+
+impl PartialEq for TimeCode {
+    fn eq(&self, other: &Self) -> bool {
+        let mut result = false;
+
+        unsafe {
+            // Function does not raise errors, so skipping error checking.
+            sys::Imf_TimeCode__eq(&self.inner, &mut result, &other.inner);
+        }
+
+        result
+    }
+
+    fn ne(&self, other: &Self) -> bool {
+        let mut result = false;
+
+        unsafe {
+            // Function does not raise errors, so skipping error checking.
+            sys::Imf_TimeCode__ne(&self.inner, &mut result, &other.inner);
+        }
+
+        result
+    }
+}
+
+impl Eq for TimeCode {}
+
+impl TimeCode {
+    /// Create a new TimeCode object.
+    ///
+    /// Errors:
+    ///
+    /// The following cases will return an error:
+    ///
+    /// - Setting hours outside of the range of 0 - 23
+    /// - Setting minutes outside of the range of 0 - 59
+    /// - Setting seconds outside of the range of 0 - 59
+    /// - Setting frame outside of the range of 0 - 29
+    ///
+    pub fn new(
+        hours: i32,
+        minutes: i32,
+        seconds: i32,
+        frame: i32,
+        drop_frame: bool,
+        color_frame: bool,
+        field_phase: bool,
+        bgf0: bool,
+        bgf1: bool,
+        bgf2: bool,
+        binary_group1: i32,
+        binary_group2: i32,
+        binary_group3: i32,
+        binary_group4: i32,
+        binary_group5: i32,
+        binary_group6: i32,
+        binary_group7: i32,
+        binary_group8: i32,
+    ) -> Result<Self> {
+        let mut inner = MaybeUninit::<sys::Imf_TimeCode_t>::uninit();
+
+        unsafe {
+            sys::Imf_TimeCode_ctor(
+                inner.as_mut_ptr(),
+                hours as c_int,
+                minutes as c_int,
+                seconds as c_int,
+                frame as c_int,
+                drop_frame,
+                color_frame,
+                field_phase,
+                bgf0,
+                bgf1,
+                bgf2,
+                binary_group1 as c_int,
+                binary_group2 as c_int,
+                binary_group3 as c_int,
+                binary_group4 as c_int,
+                binary_group5 as c_int,
+                binary_group6 as c_int,
+                binary_group7 as c_int,
+                binary_group8 as c_int,
+            )
+            .into_result()?;
+
+            Ok(Self {
+                inner: inner.assume_init(),
+            })
+        }
+    }
+
+    /// Create a new TimeCode object from the packed representation of the
+    /// object.
+    ///
+    pub fn from_time_and_flags(
+        time_and_flags: u32,
+        user_data: u32,
+        packing: TimeCodePacking,
+    ) -> Self {
+        let mut inner = MaybeUninit::<sys::Imf_TimeCode_t>::uninit();
+
+        unsafe {
+            // Function does not raise errors, so skipping error checking.
+            sys::Imf_TimeCode_from_time_and_flags(
+                inner.as_mut_ptr(),
+                time_and_flags as c_uint,
+                user_data as c_uint,
+                packing.to_sys_packing(),
+            );
+
+            Self {
+                inner: inner.assume_init(),
+            }
+        }
+    }
+
+    /// Return the hours from 0 - 23.
+    ///
+    pub fn hours(&self) -> i32 {
+        let mut result: c_int = 0;
+
+        unsafe {
+            // Function does not raise errors, so skipping error checking.
+            sys::Imf_TimeCode_hours(&self.inner, &mut result);
+        }
+
+        result as i32
+    }
+
+    /// Set the hours of the time code.
+    ///
+    /// # Errors
+    ///
+    /// Setting the hours less than 0 or greater than 23 will return an error.
+    ///
+    pub fn set_hours(&mut self, hours: i32) -> Result<()> {
+        unsafe {
+            sys::Imf_TimeCode_setHours(&mut self.inner, hours as c_int)
+                .into_result()?;
+        }
+
+        Ok(())
+    }
+
+    /// Return the minutes from 0 - 59.
+    ///
+    pub fn minutes(&self) -> i32 {
+        let mut result: c_int = 0;
+
+        unsafe {
+            // Function does not raise errors, so skipping error checking.
+            sys::Imf_TimeCode_minutes(&self.inner, &mut result);
+        }
+
+        result as i32
+    }
+
+    /// Set the minutes of the time code.
+    ///
+    /// # Errors
+    ///
+    /// Setting the minutes less than 0 or greater than 59 will return an error.
+    ///
+    pub fn set_minutes(&mut self, minutes: i32) -> Result<()> {
+        unsafe {
+            sys::Imf_TimeCode_setMinutes(&mut self.inner, minutes as c_int)
+                .into_result()?;
+        }
+
+        Ok(())
+    }
+
+    /// Return the seconds from 0 - 59.
+    ///
+    pub fn seconds(&self) -> i32 {
+        let mut result: c_int = 0;
+
+        unsafe {
+            // Function does not raise errors, so skipping error checking.
+            sys::Imf_TimeCode_seconds(&self.inner, &mut result);
+        }
+
+        result as i32
+    }
+
+    /// Set the seconds of the time code.
+    ///
+    /// # Errors
+    ///
+    /// Setting the seconds less than 0 or greater than 59 will return an error.
+    ///
+    pub fn set_seconds(&mut self, seconds: i32) -> Result<()> {
+        unsafe {
+            sys::Imf_TimeCode_setSeconds(&mut self.inner, seconds as c_int)
+                .into_result()?;
+        }
+
+        Ok(())
+    }
+
+    /// Return the frame from 0 - 29.
+    ///
+    pub fn frame(&self) -> i32 {
+        let mut result: c_int = 0;
+
+        unsafe {
+            // Function does not raise errors, so skipping error checking.
+            sys::Imf_TimeCode_frame(&self.inner, &mut result);
+        }
+
+        result as i32
+    }
+
+    /// Set the frame of the time code.
+    ///
+    /// # Errors
+    ///
+    /// Setting the frame less than 0 or greater than 29 will return an error.
+    ///
+    pub fn set_frame(&mut self, frame: i32) -> Result<()> {
+        unsafe {
+            sys::Imf_TimeCode_setFrame(&mut self.inner, frame as c_int)
+                .into_result()?;
+        }
+
+        Ok(())
+    }
+
+    /// Return if there is a drop frame.
+    ///
+    pub fn drop_frame(&self) -> bool {
+        let mut result: bool = false;
+
+        unsafe {
+            // Function does not raise errors, so skipping error checking.
+            sys::Imf_TimeCode_dropFrame(&self.inner, &mut result);
+        }
+
+        result
+    }
+
+    /// Set if there is a drop frame.
+    ///
+    pub fn set_drop_frame(&mut self, drop_frame: bool) {
+        unsafe {
+            sys::Imf_TimeCode_setDropFrame(&mut self.inner, drop_frame);
+        }
+    }
+
+    /// Return if there is a color frame.
+    ///
+    pub fn color_frame(&self) -> bool {
+        let mut result: bool = false;
+
+        unsafe {
+            // Function does not raise errors, so skipping error checking.
+            sys::Imf_TimeCode_colorFrame(&self.inner, &mut result);
+        }
+
+        result
+    }
+
+    /// Set if there is a color frame.
+    ///
+    pub fn set_color_frame(&mut self, color_frame: bool) {
+        unsafe {
+            sys::Imf_TimeCode_setColorFrame(&mut self.inner, color_frame);
+        }
+    }
+
+    /// Return if there is a field phase.
+    ///
+    pub fn field_phase(&self) -> bool {
+        let mut result: bool = false;
+
+        unsafe {
+            // Function does not raise errors, so skipping error checking.
+            sys::Imf_TimeCode_fieldPhase(&self.inner, &mut result);
+        }
+
+        result
+    }
+
+    /// Set if there is a field phase.
+    ///
+    pub fn set_field_phase(&mut self, field_phase: bool) {
+        unsafe {
+            sys::Imf_TimeCode_setFieldPhase(&mut self.inner, field_phase);
+        }
+    }
+
+    /// Return the bgf0.
+    ///
+    pub fn bgf0(&self) -> bool {
+        let mut result: bool = false;
+
+        unsafe {
+            // Function does not raise errors, so skipping error checking.
+            sys::Imf_TimeCode_bgf0(&self.inner, &mut result);
+        }
+
+        result
+    }
+
+    /// Set the bgf0.
+    ///
+    pub fn set_bgf0(&mut self, bgf0: bool) {
+        unsafe {
+            sys::Imf_TimeCode_setBgf0(&mut self.inner, bgf0);
+        }
+    }
+
+    /// Return the bgf1.
+    ///
+    pub fn bgf1(&self) -> bool {
+        let mut result: bool = false;
+
+        unsafe {
+            // Function does not raise errors, so skipping error checking.
+            sys::Imf_TimeCode_bgf1(&self.inner, &mut result);
+        }
+
+        result
+    }
+
+    /// Set the bgf1.
+    ///
+    pub fn set_bgf1(&mut self, bgf1: bool) {
+        unsafe {
+            sys::Imf_TimeCode_setBgf1(&mut self.inner, bgf1);
+        }
+    }
+
+    /// Return the bgf2.
+    ///
+    pub fn bgf2(&self) -> bool {
+        let mut result: bool = false;
+
+        unsafe {
+            // Function does not raise errors, so skipping error checking.
+            sys::Imf_TimeCode_bgf2(&self.inner, &mut result);
+        }
+
+        result
+    }
+
+    /// Set the bgf2.
+    ///
+    pub fn set_bgf2(&mut self, bgf2: bool) {
+        unsafe {
+            sys::Imf_TimeCode_setBgf2(&mut self.inner, bgf2);
+        }
+    }
+
+    /// Return the value for the binary group.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the group is not between 1 and 8.
+    ///
+    pub fn binary_group(&self, group: i32) -> Result<i32> {
+        let mut result: c_int = 0;
+
+        unsafe {
+            // Function does not raise errors, so skipping error checking.
+            sys::Imf_TimeCode_binaryGroup(
+                &self.inner,
+                &mut result,
+                group as c_int,
+            )
+            .into_result()?;
+        }
+
+        Ok(result as i32)
+    }
+
+    /// Set the binary group value.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the group is not between 1 and 8, or the value is
+    /// not between 0 and 15.
+    ///
+    pub fn set_binary_group(&mut self, group: i32, value: i32) -> Result<()> {
+        if value < 0 || value > 15 {
+            return Err(Error::InvalidArgument(
+                "Binary group value must be between 0 and 15.".into(),
+            ));
+        }
+
+        unsafe {
+            sys::Imf_TimeCode_setBinaryGroup(
+                &mut self.inner,
+                group as c_int,
+                value as c_int,
+            )
+            .into_result()?;
+        }
+
+        Ok(())
+    }
+
+    /// Return the time and flags for the given packing.
+    ///
+    pub fn time_and_flags(&self, packing: TimeCodePacking) -> u32 {
+        let mut result: c_uint = 0;
+
+        unsafe {
+            // Function does not raise errors, so skipping error checking.
+            sys::Imf_TimeCode_timeAndFlags(
+                &self.inner,
+                &mut result,
+                packing.to_sys_packing(),
+            );
+        }
+
+        result as u32
+    }
+
+    /// Set the time and flags for the given packing.
+    ///
+    pub fn set_time_and_flags(&mut self, value: u32, packing: TimeCodePacking) {
+        unsafe {
+            sys::Imf_TimeCode_setTimeAndFlags(
+                &mut self.inner,
+                value as c_uint,
+                packing.to_sys_packing(),
+            );
+        }
+    }
+
+    /// Return arbitrary user data.
+    ///
+    pub fn user_data(&self) -> u32 {
+        let mut result: c_uint = 0;
+
+        unsafe {
+            // Function does not raise errors, so skipping error checking.
+            sys::Imf_TimeCode_userData(&self.inner, &mut result);
+        }
+
+        result as u32
+    }
+
+    /// Set arbitrary user data.
+    ///
+    pub fn set_user_data(&mut self, value: u32) {
+        unsafe {
+            sys::Imf_TimeCode_setUserData(&mut self.inner, value as c_uint);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use openexr_sys as sys;
+    #[test]
+    fn test_packing_from_sys_success() {
+        let result = super::TimeCodePacking::from_sys_packing(
+            sys::Imf_TimeCode_Packing_TV60_PACKING,
+        );
+        assert_eq!(result, super::TimeCodePacking::Tv60);
+
+        let result = super::TimeCodePacking::from_sys_packing(
+            sys::Imf_TimeCode_Packing_TV50_PACKING,
+        );
+        assert_eq!(result, super::TimeCodePacking::Tv50);
+
+        let result = super::TimeCodePacking::from_sys_packing(
+            sys::Imf_TimeCode_Packing_FILM24_PACKING,
+        );
+        assert_eq!(result, super::TimeCodePacking::Film24);
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_packing_from_sys_failure_invalid_value() {
+        super::TimeCodePacking::from_sys_packing(sys::Imf_TimeCode_Packing(
+            u32::MAX,
+        ));
+    }
+
+    #[test]
+    fn test_packing_to_sys_success() {
+        let result = super::TimeCodePacking::Tv60.to_sys_packing();
+        assert_eq!(result, sys::Imf_TimeCode_Packing_TV60_PACKING);
+
+        let result = super::TimeCodePacking::Tv50.to_sys_packing();
+        assert_eq!(result, sys::Imf_TimeCode_Packing_TV50_PACKING);
+
+        let result = super::TimeCodePacking::Film24.to_sys_packing();
+        assert_eq!(result, sys::Imf_TimeCode_Packing_FILM24_PACKING);
+    }
+
+    #[test]
+    fn test_timecode_default_success() {
+        let result = super::TimeCode::default();
+        let mut is_eq = false;
+
+        unsafe {
+            sys::Imf_TimeCode__eq(
+                &result.inner,
+                &mut is_eq,
+                &sys::Imf_TimeCode_t::default(),
+            );
+        }
+
+        assert!(is_eq);
+    }
+
+    #[test]
+    fn test_timecode_new_success() {
+        let hours = 1;
+        let minutes = 2;
+        let seconds = 3;
+        let frame = 4;
+        let drop_frame = true;
+        let color_frame = true;
+        let field_phase = true;
+        let bgf0 = true;
+        let bgf1 = true;
+        let bgf2 = true;
+        let binary_group1 = 1;
+        let binary_group2 = 2;
+        let binary_group3 = 3;
+        let binary_group4 = 4;
+        let binary_group5 = 5;
+        let binary_group6 = 6;
+        let binary_group7 = 7;
+        let binary_group8 = 8;
+
+        let result = super::TimeCode::new(
+            hours,
+            minutes,
+            seconds,
+            frame,
+            drop_frame,
+            color_frame,
+            field_phase,
+            bgf0,
+            bgf1,
+            bgf2,
+            binary_group1,
+            binary_group2,
+            binary_group3,
+            binary_group4,
+            binary_group5,
+            binary_group6,
+            binary_group7,
+            binary_group8,
+        )
+        .unwrap();
+
+        assert_eq!(result.hours(), hours);
+        assert_eq!(result.minutes(), minutes);
+        assert_eq!(result.seconds(), seconds);
+        assert_eq!(result.frame(), frame);
+        assert_eq!(result.drop_frame(), drop_frame);
+        assert_eq!(result.color_frame(), color_frame);
+        assert_eq!(result.field_phase(), field_phase);
+        assert_eq!(result.bgf0(), bgf0);
+        assert_eq!(result.bgf1(), bgf1);
+        assert_eq!(result.bgf2(), bgf2);
+        assert_eq!(result.binary_group(1).unwrap(), binary_group1);
+        assert_eq!(result.binary_group(2).unwrap(), binary_group2);
+        assert_eq!(result.binary_group(3).unwrap(), binary_group3);
+        assert_eq!(result.binary_group(4).unwrap(), binary_group4);
+        assert_eq!(result.binary_group(5).unwrap(), binary_group5);
+        assert_eq!(result.binary_group(6).unwrap(), binary_group6);
+        assert_eq!(result.binary_group(7).unwrap(), binary_group7);
+        assert_eq!(result.binary_group(8).unwrap(), binary_group8);
+    }
+
+    #[test]
+    fn test_timecode_from_time_and_flags_success() {
+        let hours = 1;
+        let minutes = 2;
+        let seconds = 3;
+        let frame = 4;
+        let drop_frame = false;
+        let color_frame = false;
+        let field_phase = false;
+        let bgf0 = true;
+        let bgf1 = true;
+        let bgf2 = true;
+        let binary_group1 = 1;
+        let binary_group2 = 2;
+        let binary_group3 = 3;
+        let binary_group4 = 4;
+        let binary_group5 = 5;
+        let binary_group6 = 6;
+        let binary_group7 = 7;
+        let binary_group8 = 8;
+
+        let example = super::TimeCode::new(
+            hours,
+            minutes,
+            seconds,
+            frame,
+            drop_frame,
+            color_frame,
+            field_phase,
+            bgf0,
+            bgf1,
+            bgf2,
+            binary_group1,
+            binary_group2,
+            binary_group3,
+            binary_group4,
+            binary_group5,
+            binary_group6,
+            binary_group7,
+            binary_group8,
+        )
+        .unwrap();
+
+        let packing = super::TimeCodePacking::Film24;
+        let result = super::TimeCode::from_time_and_flags(
+            example.time_and_flags(packing),
+            example.user_data(),
+            packing,
+        );
+
+        assert_eq!(example, result);
+    }
+
+    #[test]
+    fn test_timecode_clone_success() {
+        let left = super::TimeCode::default();
+        let right = left.clone();
+
+        assert_eq!(left, right);
+    }
+
+    #[test]
+    fn test_timecode_eq_success() {
+        let left = super::TimeCode::default();
+        let right = super::TimeCode::default();
+
+        assert_eq!(left, right);
+    }
+
+    #[test]
+    fn test_timecode_ne_success() {
+        let left = super::TimeCode::default();
+        let mut right = super::TimeCode::default();
+        right.set_hours(1).unwrap();
+
+        assert_ne!(left, right);
+    }
+
+    #[test]
+    fn test_timecode_set_hours_to_min_success() {
+        let mut timecode = super::TimeCode::default();
+        timecode.set_hours(0).unwrap();
+
+        assert_eq!(timecode.hours(), 0);
+    }
+
+    #[test]
+    fn test_timecode_set_hours_to_max_success() {
+        let mut timecode = super::TimeCode::default();
+        timecode.set_hours(23).unwrap();
+
+        assert_eq!(timecode.hours(), 23);
+    }
+
+    #[test]
+    fn test_timecode_set_hours_to_less_than_min_failure() {
+        let mut timecode = super::TimeCode::default();
+        assert_eq!(timecode.set_hours(-1).is_err(), true);
+    }
+
+    #[test]
+    fn test_timecode_set_hours_to_greater_than_max_failure() {
+        let mut timecode = super::TimeCode::default();
+        assert_eq!(timecode.set_hours(24).is_err(), true);
+    }
+
+    #[test]
+    fn test_timecode_set_minutes_to_min_success() {
+        let mut timecode = super::TimeCode::default();
+        timecode.set_minutes(0).unwrap();
+
+        assert_eq!(timecode.minutes(), 0);
+    }
+
+    #[test]
+    fn test_timecode_set_minutes_to_max_success() {
+        let mut timecode = super::TimeCode::default();
+        timecode.set_minutes(59).unwrap();
+
+        assert_eq!(timecode.minutes(), 59);
+    }
+
+    #[test]
+    fn test_timecode_set_minutes_to_less_than_min_failure() {
+        let mut timecode = super::TimeCode::default();
+        assert_eq!(timecode.set_minutes(-1).is_err(), true);
+    }
+
+    #[test]
+    fn test_timecode_set_minutes_to_greater_than_max_failure() {
+        let mut timecode = super::TimeCode::default();
+        assert_eq!(timecode.set_minutes(60).is_err(), true);
+    }
+
+    #[test]
+    fn test_timecode_set_seconds_to_min_success() {
+        let mut timecode = super::TimeCode::default();
+        timecode.set_seconds(0).unwrap();
+
+        assert_eq!(timecode.seconds(), 0);
+    }
+
+    #[test]
+    fn test_timecode_set_seconds_to_max_success() {
+        let mut timecode = super::TimeCode::default();
+        timecode.set_seconds(59).unwrap();
+
+        assert_eq!(timecode.seconds(), 59);
+    }
+
+    #[test]
+    fn test_timecode_set_seconds_to_less_than_min_failure() {
+        let mut timecode = super::TimeCode::default();
+        assert_eq!(timecode.set_seconds(-1).is_err(), true);
+    }
+
+    #[test]
+    fn test_timecode_set_seconds_to_greater_than_max_failure() {
+        let mut timecode = super::TimeCode::default();
+        assert_eq!(timecode.set_seconds(60).is_err(), true);
+    }
+
+    #[test]
+    fn test_timecode_set_frame_to_min_success() {
+        let mut timecode = super::TimeCode::default();
+        timecode.set_frame(0).unwrap();
+
+        assert_eq!(timecode.frame(), 0);
+    }
+
+    #[test]
+    fn test_timecode_set_frame_to_max_success() {
+        let mut timecode = super::TimeCode::default();
+        // NOTE: There is a bug with OpenEXR where the max time code should be 29, but v3.0.1 doesn't include that fix.
+        timecode.set_frame(29).unwrap();
+
+        assert_eq!(timecode.frame(), 29);
+    }
+
+    #[test]
+    fn test_timecode_set_frame_to_less_than_min_failure() {
+        let mut timecode = super::TimeCode::default();
+        assert_eq!(timecode.set_frame(-1).is_err(), true);
+    }
+
+    #[test]
+    fn test_timecode_set_frame_to_greater_than_max_failure() {
+        let mut timecode = super::TimeCode::default();
+        // NOTE: There is a bug with OpenEXR where the max time code should be 29, but v3.0.1 doesn't include that fix.
+        // Adding a check for a frame value of 30 to address future patches.
+        assert_eq!(
+            timecode.set_frame(30).is_ok(),
+            true,
+            "OpenEXR bug fixed post v3.0.1"
+        );
+        assert_eq!(timecode.set_frame(60).is_err(), true);
+    }
+
+    #[test]
+    fn test_timecode_set_drop_frame_success() {
+        let mut timecode = super::TimeCode::default();
+        timecode.set_drop_frame(true);
+        assert_eq!(timecode.drop_frame(), true);
+        timecode.set_drop_frame(false);
+        assert_eq!(timecode.drop_frame(), false);
+    }
+
+    #[test]
+    fn test_timecode_set_color_frame_success() {
+        let mut timecode = super::TimeCode::default();
+        timecode.set_color_frame(true);
+        assert_eq!(timecode.color_frame(), true);
+        timecode.set_color_frame(false);
+        assert_eq!(timecode.color_frame(), false);
+    }
+
+    #[test]
+    fn test_timecode_set_field_phase_success() {
+        let mut timecode = super::TimeCode::default();
+        timecode.set_field_phase(true);
+        assert_eq!(timecode.field_phase(), true);
+        timecode.set_field_phase(false);
+        assert_eq!(timecode.field_phase(), false);
+    }
+
+    #[test]
+    fn test_timecode_set_bgf0_success() {
+        let mut timecode = super::TimeCode::default();
+        timecode.set_bgf0(true);
+        assert_eq!(timecode.bgf0(), true);
+        timecode.set_bgf0(false);
+        assert_eq!(timecode.bgf0(), false);
+    }
+
+    #[test]
+    fn test_timecode_set_bgf1_success() {
+        let mut timecode = super::TimeCode::default();
+        timecode.set_bgf1(true);
+        assert_eq!(timecode.bgf1(), true);
+        timecode.set_bgf1(false);
+        assert_eq!(timecode.bgf1(), false);
+    }
+
+    #[test]
+    fn test_timecode_set_bgf2_success() {
+        let mut timecode = super::TimeCode::default();
+        timecode.set_bgf2(true);
+        assert_eq!(timecode.bgf2(), true);
+        timecode.set_bgf2(false);
+        assert_eq!(timecode.bgf2(), false);
+    }
+
+    #[test]
+    fn test_timecode_set_binary_group_min_group_success() {
+        let mut timecode = super::TimeCode::default();
+        timecode.set_binary_group(1, 1).unwrap();
+        assert_eq!(timecode.binary_group(1).unwrap(), 1);
+    }
+
+    #[test]
+    fn test_timecode_set_binary_group_max_group_success() {
+        let mut timecode = super::TimeCode::default();
+        timecode.set_binary_group(8, 1).unwrap();
+        assert_eq!(timecode.binary_group(8).unwrap(), 1);
+    }
+
+    #[test]
+    fn test_timecode_set_binary_group_less_than_min_group_failure() {
+        let mut timecode = super::TimeCode::default();
+        assert_eq!(timecode.set_binary_group(0, 1).is_err(), true);
+    }
+
+    #[test]
+    fn test_timecode_set_binary_group_greater_than_max_group_failure() {
+        let mut timecode = super::TimeCode::default();
+        assert_eq!(timecode.set_binary_group(9, 1).is_err(), true);
+    }
+
+    #[test]
+    fn test_timecode_set_binary_group_min_value_success() {
+        let mut timecode = super::TimeCode::default();
+        timecode.set_binary_group(1, 0).unwrap();
+        assert_eq!(timecode.binary_group(1).unwrap(), 0);
+    }
+
+    #[test]
+    fn test_timecode_set_binary_group_max_value_success() {
+        let mut timecode = super::TimeCode::default();
+        timecode.set_binary_group(1, 15).unwrap();
+        assert_eq!(timecode.binary_group(1).unwrap(), 15);
+    }
+
+    #[test]
+    fn test_timecode_set_binary_group_less_than_min_value_failure() {
+        let mut timecode = super::TimeCode::default();
+        assert_eq!(timecode.set_binary_group(1, -1).is_err(), true);
+    }
+
+    #[test]
+    fn test_timecode_set_binary_group_greater_than_max_value_failure() {
+        let mut timecode = super::TimeCode::default();
+        assert_eq!(timecode.set_binary_group(1, 16).is_err(), true);
+    }
+
+    #[test]
+    fn test_timecode_set_time_and_flags_success() {
+        let mut timecode = super::TimeCode::default();
+        let hours = 1;
+        let minutes = 2;
+        let seconds = 3;
+        let frame = 4;
+        let drop_frame = false;
+        let color_frame = false;
+        let field_phase = false;
+        let bgf0 = true;
+        let bgf1 = true;
+        let bgf2 = true;
+        let binary_group1 = 1;
+        let binary_group2 = 2;
+        let binary_group3 = 3;
+        let binary_group4 = 4;
+        let binary_group5 = 5;
+        let binary_group6 = 6;
+        let binary_group7 = 7;
+        let binary_group8 = 8;
+
+        let example = super::TimeCode::new(
+            hours,
+            minutes,
+            seconds,
+            frame,
+            drop_frame,
+            color_frame,
+            field_phase,
+            bgf0,
+            bgf1,
+            bgf2,
+            binary_group1,
+            binary_group2,
+            binary_group3,
+            binary_group4,
+            binary_group5,
+            binary_group6,
+            binary_group7,
+            binary_group8,
+        )
+        .unwrap();
+        let packing = super::TimeCodePacking::Film24;
+        timecode.set_time_and_flags(example.time_and_flags(packing), packing);
+
+        assert_eq!(
+            timecode.time_and_flags(packing),
+            example.time_and_flags(packing)
+        );
+    }
+
+    #[test]
+    fn test_timecode_set_user_data_success() {
+        let mut timecode = super::TimeCode::default();
+        timecode.set_user_data(1);
+
+        assert_eq!(timecode.user_data(), 1);
+    }
+}


### PR DESCRIPTION
# Description

Closes #17 .

Add bindings for the time code object.

The only changes from the C++ implementation and Rust is in OpenEXR 3.0.1, the frame can be from 0 - 59, when it should be from 0 - 29 (fixed in a later commit). Also, the binary group value ranges look like they should be constrained from 0 - 15, so I added the constraint in Rust (could move fix upstream?).

# CPPMM Checklist

Cppmm is our bindings generator. There are some tools in it to aid in creating safe and stable APIs.

- [x] Use `CPPMM_RENAME(ctor)` for the "main" type constructor.
- [x] Add `CPPMM_THROWS` for any code that may throw an exception in C++.

# FFI Safety Checklist

The [Rustonomicon](https://doc.rust-lang.org/nomicon/) provides useful guides to prevent soundness errors in Rust. The [FFI section](https://doc.rust-lang.org/nomicon/ffi.html) of the document provides the source for these checklist items.

- [x] Null pointers are properly handled
- [x] Panics in Rust never cross FFI boundary
- [x] Types implement drop trait for C/C++ destructors
- [x] Concurrency is properly managed between Rust and C/C++
- [x] C style strings are converted to `CStr` or `CString`
- [x] Wrap non-trivially movable types in a `Box`

# Rust API Guidelines Checklist

The checklist is heavily inspired by [The Rust API Guidelines](https://rust-lang.github.io/api-guidelines/checklist.html). Please check each item that applies, or note if an item is intentionally skipped (either partially or fully) with the reason.

- [x] **Naming** *(crate aligns with Rust naming conventions)*
  - Casing conforms to RFC 430 ([C-CASE])
  - Ad-hoc conversions follow `as_`, `to_`, `into_` conventions ([C-CONV])
  - Getter names follow Rust convention ([C-GETTER])
  - Methods on collections that produce iterators follow `iter`, `iter_mut`, `into_iter` ([C-ITER])
  - Iterator type names match the methods that produce them ([C-ITER-TY])
  - Feature names are free of placeholder words ([C-FEATURE])
  - Names use a consistent word order ([C-WORD-ORDER])
- [x] **Interoperability** *(crate interacts nicely with other library functionality)*
  - Types eagerly implement common traits ([C-COMMON-TRAITS])
    - `Copy`, `Clone`, `Eq`, `PartialEq`, `Ord`, `PartialOrd`, `Hash`, `Debug`,
      `Display`, `Default`
  - Conversions use the standard traits `From`, `AsRef`, `AsMut` ([C-CONV-TRAITS])
  - Collections implement `FromIterator` and `Extend` ([C-COLLECT])
  - Data structures implement Serde's `Serialize`, `Deserialize` ([C-SERDE])
  - Types are `Send` and `Sync` where possible ([C-SEND-SYNC])
  - Error types are meaningful and well-behaved ([C-GOOD-ERR])
  - Binary number types provide `Hex`, `Octal`, `Binary` formatting ([C-NUM-FMT])
  - Generic reader/writer functions take `R: Read` and `W: Write` by value ([C-RW-VALUE])
- [x] **Macros** *(crate presents well-behaved macros)*
  - Input syntax is evocative of the output ([C-EVOCATIVE])
  - Macros compose well with attributes ([C-MACRO-ATTR])
  - Item macros work anywhere that items are allowed ([C-ANYWHERE])
  - Item macros support visibility specifiers ([C-MACRO-VIS])
  - Type fragments are flexible ([C-MACRO-TY])
- [x] **Documentation** *(crate is abundantly documented)*
  - Crate level docs are thorough and include examples ([C-CRATE-DOC])
  - All items have a rustdoc example ([C-EXAMPLE])
  - Examples use `?`, not `try!`, not `unwrap` ([C-QUESTION-MARK])
  - Function docs include error, panic, and safety considerations ([C-FAILURE])
  - Prose contains hyperlinks to relevant things ([C-LINK])
  - Cargo.toml includes all common metadata ([C-METADATA])
    - authors, description, license, homepage, documentation, repository,
      readme, keywords, categories
  - Crate sets html_root_url attribute "https://docs.rs/CRATE/X.Y.Z" ([C-HTML-ROOT])
  - Release notes document all significant changes ([C-RELNOTES])
  - Rustdoc does not show unhelpful implementation details ([C-HIDDEN])
- [x] **Predictability** *(crate enables legible code that acts how it looks)*
  - Smart pointers do not add inherent methods ([C-SMART-PTR])
  - Conversions live on the most specific type involved ([C-CONV-SPECIFIC])
  - Functions with a clear receiver are methods ([C-METHOD])
  - Functions do not take out-parameters ([C-NO-OUT])
  - Operator overloads are unsurprising ([C-OVERLOAD])
  - Only smart pointers implement `Deref` and `DerefMut` ([C-DEREF])
  - Constructors are static, inherent methods ([C-CTOR])
- [x] **Flexibility** *(crate supports diverse real-world use cases)*
  - Functions expose intermediate results to avoid duplicate work ([C-INTERMEDIATE])
  - Caller decides where to copy and place data ([C-CALLER-CONTROL])
  - Functions minimize assumptions about parameters by using generics ([C-GENERIC])
  - Traits are object-safe if they may be useful as a trait object ([C-OBJECT])
- [x] **Type safety** *(crate leverages the type system effectively)*
  - Newtypes provide static distinctions ([C-NEWTYPE])
  - Arguments convey meaning through types, not `bool` or `Option` ([C-CUSTOM-TYPE])
    - The `TimeCode::new` contains a bunch of bools for the drop frame, color frame, bgf0, etc. We could have a better representation.
  - Types for a set of flags are `bitflags`, not enums ([C-BITFLAG])
  - Builders enable construction of complex values ([C-BUILDER])
- [x] **Dependability** *(crate is unlikely to do the wrong thing)*
  - Functions validate their arguments ([C-VALIDATE])
  - Destructors never fail ([C-DTOR-FAIL])
  - Destructors that may block have alternatives ([C-DTOR-BLOCK])
- [x] **Debuggability** *(crate is conducive to easy debugging)*
  - All public types implement `Debug` ([C-DEBUG])
  - `Debug` representation is never empty ([C-DEBUG-NONEMPTY])
- [x] **Future proofing** *(crate is free to improve without breaking users' code)*
  - Sealed traits protect against downstream implementations ([C-SEALED])
  - Structs have private fields ([C-STRUCT-PRIVATE])
  - Newtypes encapsulate implementation details ([C-NEWTYPE-HIDE])
  - Data structures do not duplicate derived trait bounds ([C-STRUCT-BOUNDS])
- [x] **Necessities** *(to whom they matter, they really matter)*
  - Public dependencies of a stable crate are stable ([C-STABLE])
  - Crate and its dependencies have a permissive license ([C-PERMISSIVE])

# Testing Checklist

The tests are meant to validate that the wrappers are sound and work as expected. Tests that are designed to exercise code for the wrapped library and not the bindings should be added to the wrapped library instead.

- [x] `unsafe {}` code is properly sanitized
- [x] All functions are called at least once in tests
- [x] Functions that can round trip data (for example, readers and writers, getters and setters, etc) are verified so that the input and output data are the same (if applicable).


[C-CASE]: https://rust-lang.github.io/api-guidelines/naming.html#c-case
[C-CONV]: https://rust-lang.github.io/api-guidelines/naming.html#c-conv
[C-GETTER]: https://rust-lang.github.io/api-guidelines/naming.html#c-getter
[C-ITER]: https://rust-lang.github.io/api-guidelines/naming.html#c-iter
[C-ITER-TY]: https://rust-lang.github.io/api-guidelines/naming.html#c-iter-ty
[C-FEATURE]: https://rust-lang.github.io/api-guidelines/naming.html#c-feature
[C-WORD-ORDER]: https://rust-lang.github.io/api-guidelines/naming.html#c-word-order

[C-COMMON-TRAITS]: https://rust-lang.github.io/api-guidelines/interoperability.html#c-common-traits
[C-CONV-TRAITS]: https://rust-lang.github.io/api-guidelines/interoperability.html#c-conv-traits
[C-COLLECT]: https://rust-lang.github.io/api-guidelines/interoperability.html#c-collect
[C-SERDE]: https://rust-lang.github.io/api-guidelines/interoperability.html#c-serde
[C-SEND-SYNC]: https://rust-lang.github.io/api-guidelines/interoperability.html#c-send-sync
[C-GOOD-ERR]: https://rust-lang.github.io/api-guidelines/interoperability.html#c-good-err
[C-NUM-FMT]: https://rust-lang.github.io/api-guidelines/interoperability.html#c-num-fmt
[C-RW-VALUE]: https://rust-lang.github.io/api-guidelines/interoperability.html#c-rw-value

[C-EVOCATIVE]: https://rust-lang.github.io/api-guidelines/macros.html#c-evocative
[C-MACRO-ATTR]: https://rust-lang.github.io/api-guidelines/macros.html#c-macro-attr
[C-ANYWHERE]: https://rust-lang.github.io/api-guidelines/macros.html#c-anywhere
[C-MACRO-VIS]: https://rust-lang.github.io/api-guidelines/macros.html#c-macro-vis
[C-MACRO-TY]: https://rust-lang.github.io/api-guidelines/macros.html#c-macro-ty

[C-CRATE-DOC]: https://rust-lang.github.io/api-guidelines/documentation.html#c-crate-doc
[C-EXAMPLE]: https://rust-lang.github.io/api-guidelines/documentation.html#c-example
[C-QUESTION-MARK]: https://rust-lang.github.io/api-guidelines/documentation.html#c-question-mark
[C-FAILURE]: https://rust-lang.github.io/api-guidelines/documentation.html#c-failure
[C-LINK]: https://rust-lang.github.io/api-guidelines/documentation.html#c-link
[C-METADATA]: https://rust-lang.github.io/api-guidelines/documentation.html#c-metadata
[C-HTML-ROOT]: https://rust-lang.github.io/api-guidelines/documentation.html#https://rust-lang.github.io/api-guidelines/c-html-root
[C-RELNOTES]: https://rust-lang.github.io/api-guidelines/documentation.html#c-relnotes
[C-HIDDEN]: https://rust-lang.github.io/api-guidelines/documentation.html#c-hidden

[C-SMART-PTR]: https://rust-lang.github.io/api-guidelines/predictability.html#c-smart-ptr
[C-CONV-SPECIFIC]: https://rust-lang.github.io/api-guidelines/predictability.html#c-conv-specific
[C-METHOD]: https://rust-lang.github.io/api-guidelines/predictability.html#c-method
[C-NO-OUT]: https://rust-lang.github.io/api-guidelines/predictability.html#c-no-out
[C-OVERLOAD]: https://rust-lang.github.io/api-guidelines/predictability.html#c-overload
[C-DEREF]: https://rust-lang.github.io/api-guidelines/predictability.html#c-deref
[C-CTOR]: https://rust-lang.github.io/api-guidelines/predictability.html#c-ctor

[C-INTERMEDIATE]: https://rust-lang.github.io/api-guidelines/flexibility.html#c-intermediate
[C-CALLER-CONTROL]: https://rust-lang.github.io/api-guidelines/flexibility.html#c-caller-control
[C-GENERIC]: https://rust-lang.github.io/api-guidelines/flexibility.html#c-generic
[C-OBJECT]: https://rust-lang.github.io/api-guidelines/flexibility.html#c-object

[C-NEWTYPE]: type-https://rust-lang.github.io/api-guidelines/safety.html#c-newtype
[C-CUSTOM-TYPE]: type-https://rust-lang.github.io/api-guidelines/safety.html#c-custom-type
[C-BITFLAG]: type-https://rust-lang.github.io/api-guidelines/safety.html#c-bitflag
[C-BUILDER]: type-https://rust-lang.github.io/api-guidelines/safety.html#c-builder

[C-VALIDATE]: https://rust-lang.github.io/api-guidelines/dependability.html#c-validate
[C-DTOR-FAIL]: https://rust-lang.github.io/api-guidelines/dependability.html#c-dtor-fail
[C-DTOR-BLOCK]: https://rust-lang.github.io/api-guidelines/dependability.html#c-dtor-block

[C-DEBUG]: https://rust-lang.github.io/api-guidelines/debuggability.html#c-debug
[C-DEBUG-NONEMPTY]: https://rust-lang.github.io/api-guidelines/debuggability.html#c-debug-nonempty

[C-SEALED]: future-https://rust-lang.github.io/api-guidelines/proofing.html#c-sealed
[C-STRUCT-PRIVATE]: future-https://rust-lang.github.io/api-guidelines/proofing.html#c-struct-private
[C-NEWTYPE-HIDE]: future-https://rust-lang.github.io/api-guidelines/proofing.html#c-newtype-hide
[C-STRUCT-BOUNDS]: future-https://rust-lang.github.io/api-guidelines/proofing.html#c-struct-bounds

[C-STABLE]: https://rust-lang.github.io/api-guidelines/necessities.html#c-stable
[C-PERMISSIVE]: https://rust-lang.github.io/api-guidelines/necessities.html#c-permissive
