### PR TITLE
Cmake

### DIFF
--- a/bind.sh
+++ b/bind.sh
@@ -10,17 +10,22 @@ trap 'echo "\"${last_command}\" exited with code $?."' ERR
 
 rm -rf build
 
+project_name="vfx-pre-openexr"
+major_version=0
+minor_version=0
+patch_version=1
+
 astgen bind -v 1 -u -o build/ast -- \
     -I${IMATH_ROOT}/include \
     -I${IMATH_ROOT}/include/Imath \
     -I${OPENEXR_ROOT}/include \
     -I${OPENEXR_ROOT}/include/OpenEXR 
 
-asttoc build/ast -o build -p openexr \
-    -major 3 -minor 0 -patch 1 \
+asttoc build/ast -o build -p ${project_name} \
+    -major ${major_version} -minor ${minor_version} -patch ${patch_version} \
     -L $OPENEXR_ROOT/lib \
     -l OpenEXR-3_0 \
     -l OpenEXRUtil-3_0
 
-cp test.rs build/openexr-sys/src
+cp test.rs build/${project_name}-sys/src
 

--- a/bind.sh
+++ b/bind.sh
@@ -25,16 +25,29 @@ astgen bind -v 1 -u -o build/ast -- \
 # Generate c bindings from parsing json ast
 asttoc build/ast -o build -p ${project_name} \
     -major ${major_version} -minor ${minor_version} -patch ${patch_version} \
-    -L $OPENEXR_ROOT/lib \
-    -l OpenEXR-3_0 \
-    -l OpenEXRUtil-3_0
+    -fp OpenEXR -fp Imath \
+    -tll OpenEXR::OpenEXR \
+    -tll OpenEXR::OpenEXRUtil
 
 # Move the actual openexr c++ library source into
 # openexr-sys so that it comes bundled with openexr-sys.
 mkdir -p build/${project_name}-sys/thirdparty
 cp -r thirdparty/openexr build/${project_name}-sys/thirdparty/
 cp -r thirdparty/Imath build/${project_name}-sys/thirdparty/
-sed s/PROJECT_NAME/${project_name}/g; s/MAJOR_VERSION/${major_version}/g; s/MINOR_VERSION/${minor_version}/g <scripts/build.rs >build/${project_name}-sys/build.rs
+
+sed \
+    -e "s/PROJECT_NAME/${project_name}/g" \
+    -e "s/MAJOR_VERSION/${major_version}/g" \
+    -e "s/MINOR_VERSION/${minor_version}/g" \
+    -e "s/PATCH_VERSION/${patch_version}/g" \
+    scripts/build.rs > build/${project_name}-sys/build.rs
+
+sed \
+    -e "s/PROJECT_NAME/${project_name}/g" \
+    -e "s/MAJOR_VERSION/${major_version}/g" \
+    -e "s/MINOR_VERSION/${minor_version}/g" \
+    -e "s/PATCH_VERSION/${patch_version}/g" \
+    scripts/Cargo.toml > build/${project_name}-sys/Cargo.toml
 
 # Copy the tests over
 cp test.rs build/${project_name}-sys/src

--- a/openexr-rs/src/lib.rs
+++ b/openexr-rs/src/lib.rs
@@ -28,7 +28,7 @@
 //!
 //! ```bash
 //! cargo add openexr
-//! IMATH_ROOT=/path/to/imath OPENEXR_ROOT=/path/to/openexr cargo build
+//! CMAKE_PREFIX_PATH=/path/to/cmake/configs cargo build
 //! ```
 //!
 //! Note that you must take care to ensure that the version of OpenEXR you are

--- a/scripts/Cargo.toml
+++ b/scripts/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "PROJECT_NAME-sys"
+version = "MAJOR_VERSION.MINOR_VERSION.PATCH_VERSION"
+description="test package"
+license="Apache-2.0"
+authors = ["Anders Langlands <anderslanglands@gmail.com>"]
+edition = "2018"
+exclude = [
+    "thirdparty/Imath/src/ImathTest",
+    "thirdparty/Imath/src/PyImath",
+    "thirdparty/openexr/src/examples",
+    "thirdparty/openexr/src/test",
+    "thirdparty/openexr/docs",
+]
+
+[build-dependencies]
+cmake = "0.1"
+regex = "1.5.4"
+


### PR DESCRIPTION
# Description

This uses the 'modern cmake' PR on cppmm (https://github.com/vfx-rs/cppmm/pull/96) to streamline the build process. 

After running bind.sh, building the generated -sys crate will by default build using the included submodules for OpenEXR and Imath. The wrapper library openexr-c has been switched from shared to static, and now when building the submodules, the resulting (shared) libraries are copied to target/<profile> and then Rust links against those. I haven't got far enough to try it yet, but I *think* that will make it possible to have each library in a chain of dependencies build its own C++ libraries, bung them in target, then have the dependee pick them up... I think.

If you want to build against pre-installed libraries, just pass CMAKE_PREFIX_PATH as an environment variable to Cargo. When using pre-installed libraries, they are NOT copied into the local build tree. 

You can also force building the submodule libraries even when CMAKE_PREFIX_PATH is set by setting `OPENEXR_BUILD_LIBRARIES=1`. The intention here is that each crate would have its own variable like this and in this way you could set CMAKE_PREFIX_PATH for some crates, but still force others to build their submodule libraries if you wished (also if you've got CMAKE_PREFIX_PATH set in the environment for something completely unrelated).

This will definitely not work on Windows, we'll need to take a look at that separately. I've tried to set it up to work on macOS, but haven't tested so @luke-titley  if you get a chance.

I've also successfully published the -sys crate to crates.io and used it in another project both with and without CMAKE_PREFIX_PATH, so all looks good on linux.