### PR TITLE
Draft: Docker rgba build error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -85,6 +85,9 @@ RUN mkdir -p /tmp/cppmm && \
     make install && \
     rm -rf /tmp/cppmm
 
+RUN apt install -y python
+RUN apt install -y vim
+
 ENV LD_LIBRARY_PATH=/usr/local/lib:/usr/local/lib64:$LD_LIBRARY_PATH
 
 # Get useful tools

--- a/bind/c-half.cpp
+++ b/bind/c-half.cpp
@@ -57,7 +57,7 @@ public:
     unsigned short bits() const;
     void setBits(unsigned short bits);
 
-} CPPMM_OPAQUEBYTES;
+} CPPMM_VALUETYPE;
 
 } // namespace IMATH_INTERNAL_NAMESPACE
 


### PR DESCRIPTION
A fix/workaround for:
``` 
/workspaces/openexr-bind/build/openexr-sys/target/debug/build/openexr-sys-82933b9d8099b363/out/build/include/imf_rgba.h:28:18: error: field 'r' has incomplete type 'Imath_half_t' {aka 'Imath_3_0__half_t_s'}
     28 |     Imath_half_t r;
```